### PR TITLE
add image name and creation-date metadata to image metrics

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -4,6 +4,8 @@ MAINTAINER 0xO1
 
 EXPOSE 9686
 
+ENV GO111MODULE="off" GOPATH="/go"
+
 RUN apk --update add ca-certificates git && go get github.com/golang/dep/cmd/dep
 
 WORKDIR /go/src/github.com/0x0I/aws_ec2_exporter
@@ -11,7 +13,7 @@ COPY Gopkg.toml Gopkg.lock ./
 RUN dep ensure --vendor-only
 
 COPY src/ /go/src/github.com/0x0I/aws_ec2_exporter/
-RUN GOPATH=/go go get && GOPATH=/go go build -o /bin/aws-ec2-exporter
+RUN  go get && go build -o /bin/aws-ec2-exporter
 
 FROM alpine:latest
 COPY --from=builder /bin/aws-ec2-exporter /usr/bin/aws-ec2-exporter

--- a/build/build-args.yml
+++ b/build/build-args.yml
@@ -1,4 +1,4 @@
-exporter_version: 0.1.0
+exporter_version: 0.1.1
 
 build_images: true
 push_images: true

--- a/src/gather.go
+++ b/src/gather.go
@@ -143,12 +143,14 @@ func (e *Exporter) gatherImageMetrics(ch chan<- prometheus.Metric) (*ec2.Describ
 	for _, x := range result.Images {
 		log.Debug("Data <image>:", x)
 		e.counterVecs["total_images"].With(prometheus.Labels{
+			"name":                *x.Name,
 			"architecture":        *x.Architecture,
 			"hypervisor":          *x.Hypervisor,
 			"image_type":          *x.ImageType,
 			"root_device_type":    *x.RootDeviceType,
 			"state":               *x.State,
 			"virtualization_type": *x.VirtualizationType,
+			"creation_date":       *x.CreationDate,
 		}).Inc()
 	}
 

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -52,7 +52,7 @@ func AddMetrics() (map[string]*prometheus.GaugeVec, map[string]*prometheus.Count
 			Namespace: namespace,
 			Name:      "total_images",
 			Help:      "Total count of publically available images",
-		}, []string{"architecture", "hypervisor", "image_type", "root_device_type", "state", "virtualization_type"})
+		}, []string{"name", "architecture", "hypervisor", "image_type", "root_device_type", "state", "virtualization_type", "creation_date"})
 
 	// region metrics
 	counterVecs["total_regions"] = prometheus.NewCounterVec(


### PR DESCRIPTION
Enables image metric visualizations to be customized based on and according to name and creation date (likeness) values.

Also fix the following go build issue:

```
cannot use sv (type *semver.Version) as type semver.Version in field value                                                     
pkg/mod/github.com/golang/dep@v0.5.4/gps/constraint.go:122:16: invalid type assertion: c.(semver.Version) (non-interface type *semver.Constraints on left)                                    
pkg/mod/github.com/golang/dep@v0.5.4/gps/constraint.go:149:4: undefined: semver.Constraint
```